### PR TITLE
Initial Kubernetes deployment implementation

### DIFF
--- a/.github/workflows/invoke-workflow.yml
+++ b/.github/workflows/invoke-workflow.yml
@@ -52,5 +52,6 @@ jobs:
           GCP_SecretKey: ${{ secrets.GCP_SecretKey }}	
           SLURM_Token: ${{ secrets.SLURM_Token }}
           GH_PAT: ${{ secrets.GH_PAT }}
+          K8s_Token: ${{ secrets.K8s_Token }}
         run: |
           python scripts/invoke_workflow.py --workflow-file ${{ github.event.inputs.workflow_file }} 

--- a/.github/workflows/register-workflow.yml
+++ b/.github/workflows/register-workflow.yml
@@ -50,6 +50,7 @@ jobs:
           GCP_SecretKey: ${{ secrets.GCP_SecretKey }}	
           SLURM_Token: ${{ secrets.SLURM_Token }}
           GH_PAT: ${{ secrets.GH_PAT }}
+          K8s_Token: ${{ secrets.K8s_Token }}
         run: |
           # Run function registration 
           python scripts/register_workflow.py --workflow-file ${{ github.event.inputs.workflow_file }} 

--- a/kubernetes_test_workflow.json
+++ b/kubernetes_test_workflow.json
@@ -1,0 +1,72 @@
+{
+  "ActionList": {
+    "start": {
+      "Arguments": {
+        "folder": "tutorial",
+        "output1": "sample1.csv",
+        "output2": "sample2.csv"
+      },
+      "InvokeNext": [
+        "sum"
+      ],
+      "FaaSServer": "GH",
+      "Type": "R",
+      "FunctionName": "create_sample_data"
+    },
+    "sum": {
+      "FunctionName": "compute_sum",
+      "FaaSServer": "K8s",
+      "Type": "R",
+      "Arguments": {
+        "folder": "tutorial",
+        "input2": "sample2.csv",
+        "input1": "sample1.csv",
+        "output": "sum.csv"
+      },
+      "InvokeNext": []
+    }
+  },
+  "ComputeServers": {
+    "GH": {
+      "FaaSType": "GitHubActions",
+      "UserName": "JackKammerer",
+      "UseSecretStore": true,
+      "ActionRepoName": "FaaSr-workflow",
+      "Branch": "main"
+    },
+    "K8s": {
+      "FaaSType": "Kubernetes",
+      "Endpoint": "https://67.58.53.148:443",
+      "Namespace": "faasr",
+      "AllowSelfSignedCertificate": true,
+      "SSLCertificate": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRFNE1ESXhOVEExTWpNek9Wb1hEVEk0TURJeE16QTFNak16T1Zvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTTZxCm5tNUVSb3FGVHNzWWtJNUExNmZCVTJNbDN6SUpWZnN1dXY3aEpzNk1VMUlCdURuQTJQM0xkaGlpdXFpb0NNamQKRGdwcG92WTVnUVFOZXp1UVo0OGJiQmhac2dWZ1gwK3BUWUlPVjV6ZUo1bGdaclpzWHJsSWZJTHREc3BpcEo0YQpadTRiNnVuVmptSk1LeU4vTHdaRWlvU2d3MXdLRkhlcmF2czA4NHZzQ1F3R2NZNGh4bnhSNzJjdkpjdFFHeHVyCmRnUVNBd2V3U2oycXZWaGJHRzhWU3M3Mms1OU00QlIvMDhrMUxnVmF0alZtYUcvcG9VSnBETTkycVYzTnRwNjcKQUdaRnBNNjhYNHpwSU15NDlDMTNpY0hsZzRGVlNLblNiMUFvWlB0UWUrdGpNMWxTT2FPOWk3U2NxczFzWEdxYwpDazJLUFo3OEUzQUxzMVlpK0swQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFIZ3hmRmwzVkk3eW9Sbzc3M25OOGpEMDhhT1cKQmwxZldORktZQTJhY3ZTZXFsTnk4WGdkaDNMQ3JGVUI0N24vTFlaUVhEeklEVnU5M0RZQ21EbzM1dFZiMXRDMwpUL1BNd202RnpkTW1NY2M3a210dkR2YXhXNDBWbFU5WGptZ214QnhieXd3VTZLUGtCUzVZTjRGZUpEakUvSTVWCll3Ui9HeXJrS2JiL0NYbURrUDNON2orQWEvS1FXcDVPMnA3aUVibFBsTTFrazJ3Q2VVS1NuYTR0MjgvbE1CWEcKRmhNRXA2S3pIYmVXcnJKdGdjbTBLZkRkT25xZm4zbU1rYmpDbk0wV2FiZUN3eEpIWXZnbXR4RkVaTGNhODhGZAppTEF0Rms4UElUTVVXaTg2allXQmFmQkFJRW5mckJaY05mMitVMkF5S0dNN2lBeUMrZWFyQzBBOEJZOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=",
+      "MaxCPU": 500,
+      "MaxMemory": 1000,
+      "UseSecretStore": false,
+      "TimeLimit": 300,
+      "AdditionalTimeToLive": 60,
+      "NumberOfRetries": 10
+    }
+  },
+  "DataStores": {
+    "S3": {
+      "Endpoint": "https://play.min.io",
+      "Bucket": "faasr",
+      "Region": "us-east-1"
+    }
+  },
+  "ActionContainers": {
+    "start": "ghcr.io/faasr/github-actions-r:latest",
+    "sum": "ghcr.io/jackkammerer/test_kubernetes_r_faasr_test:8"
+  },
+  "FunctionInvoke": "start",
+  "DefaultDataStore": "S3",
+  "FunctionGitRepo": {
+    "create_sample_data": "FaaSr/FaaSr-Functions",
+    "compute_sum": "FaaSr/FaaSr-Functions"
+  },
+  "LoggingDataStore": "S3",
+  "FaaSrLog": "FaaSrLog",
+  "InvocationID": "tutorial",
+  "WorkflowName": "tutorial"
+}

--- a/scripts/invoke_workflow.py
+++ b/scripts/invoke_workflow.py
@@ -105,16 +105,6 @@ def add_secrets_to_server_attributes(server, faas_type):
             server["Token"] = kubernetes_token
 
 
-# This just forcefully adds the needed data store secrets to the object - only needed if a secrets store is not setup
-
-#def add_secrets_to_datastore_attributes(workflow):
-#    for name, fields in workflow["DataStores"].items():
-#        access_key = os.getenv(f"{name}_AccessKey")
-#        secret_key = os.getenv(f"{name}_SecretKey")
-#        workflow["DataStores"][name]["AccessKey"] = access_key
-#        workflow["DataStores"][name]["SecretKey"] = secret_key
-
-
 def main(testing: bool = False) -> FaaSrPayload:
     """Function invocation script"""
 
@@ -165,15 +155,9 @@ def main(testing: bool = False) -> FaaSrPayload:
     except KeyError as e:
         sys.exit(1)
 
-    # Note - this is commented out for initial demo, but it should be used for better security
-    if not use_secret_store:
-        logger.error("UseSecretStore must be true for initial action")
-        sys.exit(1)
-
     # Add secret to entry action so that Scheduler can invoke it
     faas_type = server["FaaSType"]
     add_secrets_to_server_attributes(server, faas_type)
-    #add_secrets_to_datastore_attributes(workflow)
 
     try:
         faasr_scheduler = Scheduler(workflow)

--- a/scripts/invoke_workflow.py
+++ b/scripts/invoke_workflow.py
@@ -95,6 +95,25 @@ def add_secrets_to_server_attributes(server, faas_type):
                 sys.exit(1)
             server["SLURM_Token"] = slurm_token
 
+        case "Kubernetes":            
+            kubernetes_token = os.getenv("K8s_Token")
+
+            if not kubernetes_token:
+                logger.error("K8s_Token environment variable must be set, or specified in the server configuration")
+                sys.exit(1)
+
+            server["Token"] = kubernetes_token
+
+
+# This just forcefully adds the needed data store secrets to the object - only needed if a secrets store is not setup
+
+#def add_secrets_to_datastore_attributes(workflow):
+#    for name, fields in workflow["DataStores"].items():
+#        access_key = os.getenv(f"{name}_AccessKey")
+#        secret_key = os.getenv(f"{name}_SecretKey")
+#        workflow["DataStores"][name]["AccessKey"] = access_key
+#        workflow["DataStores"][name]["SecretKey"] = secret_key
+
 
 def main(testing: bool = False) -> FaaSrPayload:
     """Function invocation script"""
@@ -146,6 +165,7 @@ def main(testing: bool = False) -> FaaSrPayload:
     except KeyError as e:
         sys.exit(1)
 
+    # Note - this is commented out for initial demo, but it should be used for better security
     if not use_secret_store:
         logger.error("UseSecretStore must be true for initial action")
         sys.exit(1)
@@ -153,6 +173,7 @@ def main(testing: bool = False) -> FaaSrPayload:
     # Add secret to entry action so that Scheduler can invoke it
     faas_type = server["FaaSType"]
     add_secrets_to_server_attributes(server, faas_type)
+    #add_secrets_to_datastore_attributes(workflow)
 
     try:
         faasr_scheduler = Scheduler(workflow)

--- a/scripts/invoke_workflow.py
+++ b/scripts/invoke_workflow.py
@@ -155,6 +155,10 @@ def main(testing: bool = False) -> FaaSrPayload:
     except KeyError as e:
         sys.exit(1)
 
+    if not use_secret_store:
+        logger.error("UseSecretStore must be true for initial action")
+        sys.exit(1)
+
     # Add secret to entry action so that Scheduler can invoke it
     faas_type = server["FaaSType"]
     add_secrets_to_server_attributes(server, faas_type)

--- a/scripts/native_containers.txt
+++ b/scripts/native_containers.txt
@@ -4,6 +4,8 @@ faasr/slurm-python:latest
 faasr/openwhisk-r:latest
 faasr/gcp-r:latest
 faasr/slurm-r:latest
+faasr/kubernetes-r:latest
+faasr/kubernetes-python:latest
 ghcr.io/faasr/github-actions-python:latest
 ghcr.io/faasr/github-actions-r:latest
 145342739029.dkr.ecr.us-east-1.amazonaws.com/aws-lambda-python:latest

--- a/scripts/register_workflow.py
+++ b/scripts/register_workflow.py
@@ -98,6 +98,9 @@ def generate_github_secret_imports(faasr_payload):
             case "SLURM":
                 token = f"{faas_name}_Token"
                 import_statements.append(f"{token}: ${{{{ secrets.{token}}}}}")
+            case "Kubernetes":
+                token = f"K8s_Token"
+                import_statements.append(f"{token}: ${{{{ secrets.{token}}}}}")
             case _:
                 logger.error(
                     f"Unknown FaaSType ({faas_type}) for compute server: {faas_name} - cannot generate secrets"  # noqa E501
@@ -1049,6 +1052,146 @@ def get_slurm_resource_requirements(action_name, action_config, server_config):
     return config
 
 
+def deploy_to_kubernetes(workflow_data):
+    """
+    Validate Kubernetes configuration and test connectivity
+    This function validates the configuration and tests the connection
+    
+    Args:
+        workflow_data: Full workflow JSON
+    """
+    logger.info("Validating Kubernetes configuration...")
+
+    # Find all of the Kubernetes actions
+    kubernetes_clusters = {}
+
+    for _, action_data in workflow_data["ActionList"].items():
+        cluster_name = action_data["FaaSServer"]
+        cluster_config = workflow_data["ComputeServers"][cluster_name]
+        faas_type = cluster_config.get("FaaSType", "")
+
+        if faas_type.lower() == "kubernetes":
+            if cluster_name not in kubernetes_clusters:
+                kubernetes_clusters[cluster_name] = cluster_config.copy()
+
+
+    if len(kubernetes_clusters) == 0:
+        logger.info("No actions found for Kubernetes deployment")
+        return
+    
+    for cluster_name, cluster_config in kubernetes_clusters.items():
+        validate_kubernetes_cluster_config(cluster_name, cluster_config)
+
+        if not test_kubernetes_connectivity(cluster_name, cluster_config):
+            logger.error(f"Failed to connect to Kubernetes cluster: {cluster_name}")
+            sys.exit(1)
+    
+    logger.info(
+        f"Kubernetes configuration validated successfully\n"
+        f"No persistent resources were created - this job will be submitted to the cluster at invocation time"
+    )
+
+
+def validate_kubernetes_cluster_config(cluster_name, cluster_config):
+    """
+    Valiate Kubernetes cluster configuration has required fields.
+    
+    ARgs:
+        cluster_name: Name of the Kubernetes server
+        cluster_config: Cluster configuration dictionary
+    """
+
+    required_fields = ["Endpoint"]
+    missing_fields = [f for f in required_fields if not cluster_config.get(f)]
+
+    if missing_fields:
+        logger.error(
+            f"Kubernetes cluster: {cluster_name} configuration is missing the following required fields: "
+            f"{', '.join(missing_fields)}"
+        )
+        sys.exit(1)
+    
+    logger.info(
+        f"Kubernetes cluster configuration validated: "
+        f"Connecting to: {cluster_config['Endpoint']}"
+    )
+
+
+def test_kubernetes_connectivity(cluster_name, cluster_config):
+    """
+    Test connectivity to the Kubernetes cluster REST API endpoint
+    
+    Args:
+        cluster_name: Name of the Kubernetes cluster
+        cluster_config: Server configuration dictionary
+    
+    Returns:
+        bool: True if the connectivity test passes
+    """
+
+    endpoint = cluster_config["Endpoint"]
+    namespace = cluster_config.get("Namespace", "default")
+
+    #Ensure the endpoint contains the needed protocol
+    if not endpoint.startswith("http"):
+        endpoint = f"https://{endpoint}"
+    
+    # Test the endpoint
+    jobs_url = f"{endpoint}/apis/batch/v1/namespaces/{namespace}/jobs"
+
+    headers = {"Accept": "application/json"}
+
+    kubernetes_token = os.getenv(f"K8s_Token")
+
+    if kubernetes_token:
+        headers["Authorization"] = f"Bearer {kubernetes_token}"
+
+        # Validate token format
+        if not kubernetes_token.startswith("eyJ"):
+            logger.error(
+                f"K8s_Token doesn't appear to be a valid JWT token for the cluster: {cluster_name}. This is required to schedule jobs!"
+            )
+            return False
+        
+    else:
+        logger.error(
+            f"K8s_Token must be provided to retrieve the jobs! Please ensure the value K8s_Token, with the appropriate JWT, is included in yours secrets!"
+        )
+
+        return False
+    
+
+    try:
+        response = requests.get(jobs_url, headers=headers, verify=False, timeout=10)
+
+        if response.status_code == 200:
+            logger.info(
+                f"Kubernetes cluster connectivity test passed for: {cluster_name} - "
+                f"The endpoint: {endpoint} is reachable and authentication is configured properly!"
+            )
+            logger.info(f"{response.text}")
+            return True
+        elif response.status_code in [401, 403]:
+            logger.info(
+                f"Kubernetes cluster endpoint reachable at: {cluster_name}"
+                "However, authentication is required to use Kubernetes!"
+            )
+
+            response.text
+            return False
+        else:
+            logger.error(
+                f"Kubernetes cluster connectivity test failed: HTTP {response.status_code} - "
+                f"{response.text[:200]}"
+            )
+            return False
+        
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Kubernetes cluster connectivity error for '{cluster_name}': {e}")
+        return False
+            
+
+
 def main():
     args = parse_arguments()
     workflow_data = read_workflow_file(args.workflow_file)
@@ -1092,6 +1235,8 @@ def main():
             deploy_to_gcp(workflow_data)
         elif faas_type == "slurm":
             deploy_to_slurm(workflow_data)
+        elif faas_type == "kubernetes":
+            deploy_to_kubernetes(workflow_data)
         else:
             logger.error(f"Unsupported FaaSType: {faas_type}")
             sys.exit(1)

--- a/scripts/register_workflow.py
+++ b/scripts/register_workflow.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import textwrap
 import time
+import base64
 
 import boto3
 import requests
@@ -1117,6 +1118,29 @@ def validate_kubernetes_cluster_config(cluster_name, cluster_config):
     )
 
 
+def validate_certificate(certificate):
+    """
+    Test that the certificate is in the correct format, and if it is base64 encoded, decode it to the proper format 
+
+    Args:
+        certificate: The string representing the certificate from the workflow
+
+    Returns:
+        string: The validated, or decoded certificate
+    """
+
+    if ("-----BEGIN CERTIFICATE-----" in certificate and "-----END CERTIFICATE-----" in certificate):
+        return (True, certificate)
+
+    else:
+        certificate = base64.b64decode(certificate).decode('utf-8')
+        if (certificate and "-----BEGIN CERTIFICATE-----" in certificate and "-----END CERTIFICATE-----" in certificate):
+           return (True, certificate)
+
+    return (False, None) 
+
+
+
 def test_kubernetes_connectivity(cluster_name, cluster_config):
     """
     Test connectivity to the Kubernetes cluster REST API endpoint
@@ -1131,6 +1155,13 @@ def test_kubernetes_connectivity(cluster_name, cluster_config):
 
     endpoint = cluster_config["Endpoint"]
     namespace = cluster_config.get("Namespace", "default")
+    certificate = cluster_config.get("SSLCertificate")
+
+    if (certificate != None):
+        (isValid, certificate) = validate_certificate(certificate)
+        if (not isValid):
+            logger.error(f"The provided certificate is invalid! Please either provide a valid certificate or remove it if unncessary!")
+            return False 
 
     #Ensure the endpoint contains the needed protocol
     if not endpoint.startswith("http"):
@@ -1151,6 +1182,7 @@ def test_kubernetes_connectivity(cluster_name, cluster_config):
             logger.error(
                 f"K8s_Token doesn't appear to be a valid JWT token for the cluster: {cluster_name}. This is required to schedule jobs!"
             )
+            
             return False
         
     else:
@@ -1159,10 +1191,20 @@ def test_kubernetes_connectivity(cluster_name, cluster_config):
         )
 
         return False
-    
+
+
+    s = requests.Session()
+
+    if (certificate):
+        with open("./temp.pem", "w") as certFile:
+            certFile.write(certificate)
+        
+        s.verify = "./temp.pem"
+
+    return_value = True
 
     try:
-        response = requests.get(jobs_url, headers=headers, verify=False, timeout=10)
+        response = s.get(jobs_url, headers=headers, timeout=10)
 
         if response.status_code == 200:
             logger.info(
@@ -1170,25 +1212,32 @@ def test_kubernetes_connectivity(cluster_name, cluster_config):
                 f"The endpoint: {endpoint} is reachable and authentication is configured properly!"
             )
             logger.info(f"{response.text}")
-            return True
+            
         elif response.status_code in [401, 403]:
             logger.info(
                 f"Kubernetes cluster endpoint reachable at: {cluster_name}"
-                "However, authentication is required to use Kubernetes!"
+                "However, authentication is required to use Kubernetes!",
+                f"{response.text[:200]}"
             )
 
-            response.text
-            return False
+            return_value = False
         else:
             logger.error(
                 f"Kubernetes cluster connectivity test failed: HTTP {response.status_code} - "
                 f"{response.text[:200]}"
             )
-            return False
-        
+
+            return_value = False
+    
+    except requests.exceptions.SSLError as e:
+        logger.error(f"Kubernetes cluster connectivity test failed for '{cluster_name}' due to an invalid SSL certificate! Either the certificate was not provided or is invalid: {e}")
     except requests.exceptions.RequestException as e:
         logger.error(f"Kubernetes cluster connectivity error for '{cluster_name}': {e}")
-        return False
+
+    if (certificate):
+        os.remove("./temp.pem")
+    return return_value
+
             
 
 

--- a/scripts/register_workflow.py
+++ b/scripts/register_workflow.py
@@ -100,7 +100,7 @@ def generate_github_secret_imports(faasr_payload):
                 token = f"{faas_name}_Token"
                 import_statements.append(f"{token}: ${{{{ secrets.{token}}}}}")
             case "Kubernetes":
-                token = f"K8s_Token"
+                token = f"{faas_name}_Token"
                 import_statements.append(f"{token}: ${{{{ secrets.{token}}}}}")
             case _:
                 logger.error(

--- a/scripts/register_workflow.py
+++ b/scripts/register_workflow.py
@@ -1168,7 +1168,7 @@ def test_kubernetes_connectivity(cluster_name, cluster_config):
         endpoint = f"https://{endpoint}"
     
     # Test the endpoint
-    jobs_url = f"{endpoint}/apis/batch/v1/namespaces/{namespace}/jobs"
+    jobs_url = f"{endpoint}/apis/authorization.k8s.io/v1/selfsubjectaccessreviews"
 
     headers = {"Accept": "application/json"}
 
@@ -1192,8 +1192,20 @@ def test_kubernetes_connectivity(cluster_name, cluster_config):
 
         return False
 
-
     s = requests.Session()
+
+    job_payload = {
+        "apiVersion": "authorization.k8s.io/v1",
+        "kind": "SelfSubjectAccessReview",
+        "spec": {
+            "resourceAttributes": {
+                "namespace": f"{namespace}",
+                "verb": "create",
+                "group": "batch",
+                "resource": "jobs"
+            }
+        }
+    }
 
     if (certificate):
         with open("./temp.pem", "w") as certFile:
@@ -1204,15 +1216,25 @@ def test_kubernetes_connectivity(cluster_name, cluster_config):
     return_value = True
 
     try:
-        response = s.get(jobs_url, headers=headers, timeout=10)
+        response = s.post(jobs_url, headers=headers, timeout=10, json=job_payload)
 
-        if response.status_code == 200:
-            logger.info(
-                f"Kubernetes cluster connectivity test passed for: {cluster_name} - "
-                f"The endpoint: {endpoint} is reachable and authentication is configured properly!"
-            )
-            logger.info(f"{response.text}")
-            
+        if response.status_code == 200 or response.status_code == 201:
+            result_json = response.json()
+
+            if (result_json["status"]["allowed"] == True):
+                logger.info(
+                    f"Kubernetes cluster connectivity test passed for: {cluster_name} - "
+                    f"The endpoint: {endpoint} is reachable and authentication is configured properly!"
+                )
+            else:
+                logger.info(
+                    f"Kubernetes cluster endpoint reachable at: {cluster_name}"
+                    "However, this service account does not have the permissions needed to create a new job!"
+                    f"This is the additional error information: {response.text[:200]}"
+                )
+                return_value = False
+
+
         elif response.status_code in [401, 403]:
             logger.info(
                 f"Kubernetes cluster endpoint reachable at: {cluster_name}"

--- a/scripts/register_workflow.py
+++ b/scripts/register_workflow.py
@@ -12,6 +12,9 @@ import base64
 
 import boto3
 import requests
+import ssl
+
+from requests.adapters import HTTPAdapter
 from FaaSr_py import graph_functions as faasr_gf
 from github import Github
 
@@ -23,6 +26,17 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+class LaxSSLAdapter(HTTPAdapter):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False, **pool_kwargs):
+        # Pass the custom context to urllib3's PoolManager
+        ctx = ssl.create_default_context()
+        ctx.verify_flags &= ~ssl.VERIFY_X509_STRICT
+
+        pool_kwargs['ssl_context'] = ctx
+        return super().init_poolmanager(connections, maxsize, block, **pool_kwargs)
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
@@ -1155,8 +1169,9 @@ def test_kubernetes_connectivity(cluster_name, cluster_config):
 
     endpoint = cluster_config["Endpoint"]
     namespace = cluster_config.get("Namespace", "default")
+    allowSelfSignedCertificate = cluster_config.get("AllowSelfSignedCertificate")
     certificate = cluster_config.get("SSLCertificate")
-
+    
     if (certificate != None):
         (isValid, certificate) = validate_certificate(certificate)
         if (not isValid):
@@ -1193,6 +1208,12 @@ def test_kubernetes_connectivity(cluster_name, cluster_config):
         return False
 
     s = requests.Session()
+
+    if (allowSelfSignedCertificate):
+        # Create an adapter that removes the stricter certificate checks
+        # Should allow self-signed certs
+        adapter = LaxSSLAdapter()
+        s.mount("https://", adapter)
 
     job_payload = {
         "apiVersion": "authorization.k8s.io/v1",
@@ -1253,8 +1274,10 @@ def test_kubernetes_connectivity(cluster_name, cluster_config):
     
     except requests.exceptions.SSLError as e:
         logger.error(f"Kubernetes cluster connectivity test failed for '{cluster_name}' due to an invalid SSL certificate! Either the certificate was not provided or is invalid: {e}")
+        return_value = False
     except requests.exceptions.RequestException as e:
         logger.error(f"Kubernetes cluster connectivity error for '{cluster_name}': {e}")
+        return_value = False
 
     if (certificate):
         os.remove("./temp.pem")


### PR DESCRIPTION
The most important changes are the _register_workflow.py_ changes, which do not actually register any containers with the Kubernetes cluster (invoke can add and run the job in one step), but validate the workflow configuration and then test the connectivity by listing the jobs on the Kubernetes cluster. Essentially, if the service account can be authenticated, and the jobs can be listed, then the cluster is correctly specified and accessible. The other changes are to pass tokens to the scheduler for invoking workflows.


There are a few changes I need to make to the code before it can be merged:

There is a potential validation issue for _register_workflow.py_, where a service account may be able to list jobs, but not create jobs. I'll work on figuring out if there is an easy way to verify the create job permission, but the current implementation is the bare minimum that accounts for most potential issues on a cluster.

_invoke_workflow.py_ will remain mostly the same, but there is some commented-out code that allows environment secrets to be gained directly from the environment, without using a secret store. This code is only needed for Kubernetes exclusive workflows. It was also used in my demo of the working Kubernetes code, and if anyone wants to test it out, it is included. This will be completely removed before merging. 

Finally, the "verify=False" section in the Python requests made in _register_workflow.py_ needs to be removed. This is also an issue in the FaaSr-Backend code. This is a self-signed certificate issue, which is relevant as the NRP Nautilus cluster this code will ideally be used for uses self-signed certificates. I am working on a fix for this issue for the backend and this code, so this should be updated soon.

This code is still a work in progress, but the basic components are implemented. Let me know if there are any other issues I should address!